### PR TITLE
Added state transitions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,8 +218,9 @@ namespace bwa {
 
 #### Members
 
-Class members should be named using **[snake_case](https://en.wikipedia.org/wiki/Snake_case)**
-and prefixed by an `_` (underscore). Members should always go below methods
+Class members should be named using lower **[camelCase](https://en.wikipedia.org/wiki/Camel_case)**,
+except for constants, and prefixed by an `_` (underscore).
+Members should always go below methods.
 
 ```cpp
 namespace bwa {
@@ -227,8 +228,8 @@ namespace bwa {
     protected:
         static const int _SOME_STATIC_CONST_INT;
         const int _SOME_CONST_INT;
-        static int _some_static_int;
-        int _some_int;
+        static int _someStaticInt;
+        int _someInt;
     };
 }
 ```

--- a/bwa/src/Game.cpp
+++ b/bwa/src/Game.cpp
@@ -64,6 +64,8 @@ void bwa::Game::run() {
 
 	// Normal window event loop
 	while (_window.isOpen()) {
+		_stateHandler.handleTransitions();
+
 		sf::Event e;
 		while (_window.pollEvent(e)) {
 			if (e.type == sf::Event::Closed ||

--- a/bwa/src/GameState.cpp
+++ b/bwa/src/GameState.cpp
@@ -1,5 +1,8 @@
 #include "GameState.hpp"
 
+bwa::GameState::GameState(bwa::StateHandler& stateHandler)
+	: _stateHandler(stateHandler) {}
+
 void bwa::GameState::pause() {
 	// default pause behavior
 }

--- a/bwa/src/GameState.hpp
+++ b/bwa/src/GameState.hpp
@@ -3,9 +3,11 @@
 #include <TGUI/TGUI.hpp>
 
 namespace bwa {
+	class StateHandler;
+
 	class GameState {
 	public:
-		GameState() = default;
+		GameState(StateHandler& stateHandler);
 		GameState(const GameState&) = delete;
 		GameState& operator=(const GameState&) = delete;
 
@@ -17,5 +19,6 @@ namespace bwa {
 
 	protected:
 		tgui::Gui _gui;
+		StateHandler& _stateHandler;
 	};
 }

--- a/bwa/src/InitState.cpp
+++ b/bwa/src/InitState.cpp
@@ -1,6 +1,9 @@
 #include "InitState.hpp"
+#include "PlayState.hpp"
+#include "StateHandler.hpp"
 
-bwa::InitState::InitState(sf::RenderWindow& window, const sol::state& lua) {
+bwa::InitState::InitState(StateHandler& stateHandler, sf::RenderWindow& window, const sol::state& lua)
+	: GameState(stateHandler) {
 	_gui.setWindow(window);
 
 	// Pulls the window dimensions from the window
@@ -41,6 +44,7 @@ bwa::InitState::InitState(sf::RenderWindow& window, const sol::state& lua) {
 	btnPlay->setSize(windowWidth, BUTTON_HEIGHT);
 	btnPlay->setPosition(0, windowHeight - BUTTON_Y_OFFSET);
 	btnPlay->setText("Play");
+	btnPlay->connect("pressed", [&] {_stateHandler.pushState<PlayState>(std::ref(window)); });
 	_gui.add(btnPlay);
 
 	// Settings button

--- a/bwa/src/InitState.hpp
+++ b/bwa/src/InitState.hpp
@@ -5,7 +5,7 @@
 namespace bwa {
 	class InitState final : public GameState {
 	public:
-		InitState(sf::RenderWindow& window, const sol::state& lua);
+		InitState(StateHandler& stateHandler, sf::RenderWindow& window, const sol::state& lua);
 		InitState(const InitState&) = delete;
 		InitState& operator=(const InitState&) = delete;
 

--- a/bwa/src/PlayState.cpp
+++ b/bwa/src/PlayState.cpp
@@ -1,6 +1,7 @@
 #include "PlayState.hpp"
 
-bwa::PlayState::PlayState(sf::RenderWindow& window) {
+bwa::PlayState::PlayState(StateHandler& stateHandler, sf::RenderWindow& window)
+	: GameState(stateHandler) {
 	_gui.setWindow(window);
 	auto lblName = std::make_shared<tgui::Label>();
 	lblName->setText("PlayState");

--- a/bwa/src/PlayState.hpp
+++ b/bwa/src/PlayState.hpp
@@ -4,7 +4,7 @@
 namespace bwa {
 	class PlayState final : public GameState {
 	public:
-		PlayState(sf::RenderWindow& window);
+		PlayState(StateHandler& stateHandler, sf::RenderWindow& window);
 		PlayState(const PlayState&) = delete;
 		PlayState& operator=(const PlayState&) = delete;
 

--- a/bwa/src/ResourceLoader.hpp
+++ b/bwa/src/ResourceLoader.hpp
@@ -32,7 +32,7 @@ namespace bwa {
 			it will be overwritten.
 		*/
 		template <typename F, typename... Args>
-		static bool loadHelper(const std::string& key, F&& f, Args&&... args) {
+		static inline bool loadHelper(const std::string& key, F&& f, Args&&... args) {
 			auto ptr = std::make_shared<T>();
 
 			/*
@@ -64,7 +64,7 @@ namespace bwa {
 			loadFromFile function ex: (sf::Texture).
 		*/
 		template <typename U = T>
-		static auto load(const std::string& filename) -> decltype(std::declval<U>().loadFromFile("")) {
+		static inline auto load(const std::string& filename) -> decltype(std::declval<U>().loadFromFile("")) {
 			return loadHelper(filename, [](U* ptr, const std::string& filename) {
 				return ptr->loadFromFile(filename);
 			}, filename);
@@ -75,7 +75,7 @@ namespace bwa {
 			openFromFile function ex: (sf::Music).
 		*/
 		template <typename U = T, int = 0>
-		static auto load(const std::string& filename) -> decltype(std::declval<U>().openFromFile("")) {
+		static inline auto load(const std::string& filename) -> decltype(std::declval<U>().openFromFile("")) {
 			return loadHelper(filename, [](U* ptr, const std::string& filename) {
 				return ptr->openFromFile(filename);
 			}, filename);
@@ -89,7 +89,7 @@ namespace bwa {
 			exists it'll fetch it from the cache. If not it'll
 			load it first and then return it to you.
 		*/
-		static std::shared_ptr<T> get(const std::string& filename) {
+		static inline std::shared_ptr<T> get(const std::string& filename) {
 			/*
 				Checks if 'filename' hasn't been loaded,
 				if it hasn't then it calls the load function

--- a/bwa/src/StateHandler.cpp
+++ b/bwa/src/StateHandler.cpp
@@ -14,3 +14,25 @@ void bwa::StateHandler::draw(sf::RenderWindow& window) {
 	if (!_states.empty())
 		_states.top()->draw(window);
 }
+
+void bwa::StateHandler::popState() {
+	_event = Event::Pop;
+}
+
+void bwa::StateHandler::handleTransitions() {
+	switch (_event) {
+	case Event::Push:
+		if (!_states.empty())
+			_states.top()->pause();
+		_states.push(std::move(_temp));
+		break;
+	case Event::Pop:
+		if (!_states.empty()) {
+			_states.pop();
+			if (!_states.empty())
+				_states.top()->resume();
+		}
+		break;
+	}
+	_event = Event::Null;
+}

--- a/bwa/src/StateHandler.hpp
+++ b/bwa/src/StateHandler.hpp
@@ -17,22 +17,24 @@ namespace bwa {
 		void draw(sf::RenderWindow& window);
 
 		template <typename State, typename... Args>
-		void pushState(Args&&... args) {
-			auto state = std::make_unique<State>(std::forward<Args>(args)...);
-			if (!_states.empty())
-				_states.top()->pause();
-			_states.push(std::move(state));
-		}
+		void pushState(Args&&... args);
 
-		void popState() {
-			if (!_states.empty()) {
-				_states.pop();
-				if (!_states.empty())
-					_states.top()->resume();
-			}
-		}
+		void popState();
+		void handleTransitions();
 
 	private:
+		enum class Event {
+			Null,
+			Push,
+			Pop
+		} _event;
+		std::unique_ptr<GameState> _temp;
 		std::stack<std::unique_ptr<GameState>> _states;
 	};
+
+	template<typename State, typename ...Args>
+	inline void StateHandler::pushState(Args&& ...args) {
+		_temp = std::make_unique<State>(std::ref(*this), std::forward<Args>(args)...);
+		_event = Event::Push;
+	}
 }


### PR DESCRIPTION
State transitions are done using an event based approach. Calling the functions `pushState` and `popState` in the `StateHandler` class internally creates an event that is later processed by the `handleTransitions` function. The reason for this is because I did not want the states to be able to directly modify the stack of the states. This would be bad for example if a state calls `popState` and it is the only state in the stack. My approach allows states to send an event to the `StateHandler` that is later handled *outside* any state code. Currently only the buttons `Play` and `Exit` work. 